### PR TITLE
feat(docker): update debian version to bullseye

### DIFF
--- a/docker/debian/Dockerfile
+++ b/docker/debian/Dockerfile
@@ -54,12 +54,10 @@ RUN apt-get install -y git libcurl4-openssl-dev libzmq3-dev libczmq-dev
 COPY --from=build /home/osrm/osrm-backend-5.26.0/build/OSRM-0.1.1-Linux.tar.gz ./
 RUN tar -xzvf OSRM-0.1.1-Linux.tar.gz && cd OSRM-0.1.1-Linux && cp -r bin/* /usr/bin/ && cp -r lib/* /usr/lib/ && cp -r include/* /usr/include/ && cp -r share/* /usr/share/
 
-## Installation prime-server
-COPY --from=build /usr/local/lib/libprime_server.so.0.0.0 /usr/lib/libprime_server.so.0.0.0
+### Installation prime-server
+COPY --from=build /usr/local/lib/libprime_server.so.0.7.0 /usr/lib/libprime_server.so.0.0.0
 COPY --from=build /usr/local/lib/libprime_server.so.0 /usr/lib/libprime_server.so.0
 COPY --from=build /usr/local/lib/libprime_server.so /usr/lib/libprime_server.so
-COPY --from=build /usr/local/lib/libprime_server.la /usr/lib/libprime_server.la
-COPY --from=build /usr/local/lib/libprime_server.a /usr/lib/libprime_server.a
 
 ### Installation de valhalla
 COPY --from=build /home/valhalla/valhalla/build/valhalla-3.2.0-Linux.tar.gz ./

--- a/docker/debian/Dockerfile
+++ b/docker/debian/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.10.9-slim-buster as build
+FROM python:3.10.9-slim-bullseye as build
 
 ### Installation des dépendances
 RUN apt update && apt install -y wget git g++ cmake libboost-dev libboost-filesystem-dev libboost-thread-dev \
@@ -30,7 +30,7 @@ RUN pip install conan
 RUN git clone --branch 3.2.0-with_hard_exclude --depth 1 --recursive https://github.com/IGNF/valhalla.git && cd valhalla && \
 mkdir build && cmake -B build -DCMAKE_BUILD_TYPE=Release && make -C build && make -C build package
 
-FROM python:3.10.9-slim-buster as r2gg
+FROM python:3.10.9-slim-bullseye as r2gg
 
 ENV PYTHON_VERSION "3.10.9"
 ENV HOME=/home

--- a/docker/debian/Dockerfile
+++ b/docker/debian/Dockerfile
@@ -21,9 +21,9 @@ apt-get install -y libgeos-dev libgeos++-dev libluajit-5.1-dev libspatialite-dev
 apt-get install -y libsqlite3-mod-spatialite
 
 WORKDIR /home/prime-server
-RUN apt-get install -y git autoconf automake pkg-config libtool make gcc g++ lcov libcurl4-openssl-dev libzmq3-dev libczmq-dev
+RUN apt-get install -y git cmake autoconf automake pkg-config libtool make gcc g++ lcov libcurl4-openssl-dev libzmq3-dev libczmq-dev
 RUN git clone --depth 1 --recursive https://github.com/kevinkreiser/prime_server.git && cd prime_server && \
-./autogen.sh && ./configure && make && make install
+cmake -B build . && cmake --build build && make -C build install
 
 WORKDIR /home/valhalla/
 RUN pip install conan


### PR DESCRIPTION
Debian 10 (buster) has been superseded by Debian 11 (bullseye). 

This PR update docker image to use bullseye instead of buster.

- use of cmake for prime-server build to avoid issue in link with pthread (same command used in road2 docker file : https://github.com/IGNF/road2/blob/9c54314e03d0f507f08553201d28f6d69045a478/docker/distributions/debian/Dockerfile#L14)
