### PR TITLE
Remove setuptools requirement from base requirements

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,5 +1,4 @@
 lxml==4.6.4
 psycopg2==2.9.1
-setuptools==45.2.0
 sqlparse==0.4.2
 osmium==3.2.0


### PR DESCRIPTION
I remove setuptools requirement from base requirements because it is not a requirement to run r2gg. It is a package requirement.