### PR TITLE
[fix] delete name attribute inside docker conf

### DIFF
--- a/docker/config/bdtopo2pgr.json
+++ b/docker/config/bdtopo2pgr.json
@@ -78,11 +78,6 @@
               "baseId": "base_sortie",
               "attributes": [
                 {
-                  "key": "name",
-                  "column": "way_names",
-                  "default": "false"
-                },
-                {
                   "key": "nom_1_gauche",
                   "column": "nom_1_gauche",
                   "default": "true"
@@ -365,7 +360,6 @@
             {
               "id": "waysAttributes",
               "values": [
-                "name",
                 "nom_1_gauche",
                 "nom_1_droite",
                 "cpx_numero",

--- a/docker/config/bduni2pgr_idf.json
+++ b/docker/config/bduni2pgr_idf.json
@@ -78,11 +78,6 @@
               "baseId": "base_sortie",
               "attributes": [
                 {
-                  "key": "name",
-                  "column": "way_names",
-                  "default": "false"
-                },
-                {
                   "key": "nom_1_gauche",
                   "column": "nom_1_gauche",
                   "default": "true"
@@ -366,7 +361,6 @@
             {
               "id": "waysAttributes",
               "values": [
-                "name",
                 "nom_1_gauche",
                 "nom_1_droite",
                 "cpx_numero",

--- a/docker/config/bduni2smartpgr_idf.json
+++ b/docker/config/bduni2smartpgr_idf.json
@@ -89,11 +89,6 @@
               "baseId": "base_sortie",
               "attributes": [
                 {
-                  "key": "name",
-                  "column": "way_names",
-                  "default": "false"
-                },
-                {
                   "key": "nom_1_gauche",
                   "column": "nom_1_gauche",
                   "default": "true"
@@ -376,7 +371,6 @@
             {
               "id": "waysAttributes",
               "values": [
-                "name",
                 "nom_1_gauche",
                 "nom_1_droite",
                 "cpx_numero",


### PR DESCRIPTION
A part of the conf was useless. I removed it. 