### PR TITLE
fix(road2config): default value for pop to avoid exception

### DIFF
--- a/r2gg/_main.py
+++ b/r2gg/_main.py
@@ -464,7 +464,7 @@ def write_road2_config(config, resource, logger, convert_file_paths = True):
         elif source['type'] == "valhalla":
             source.pop("mapping", None)
             for cost in source["costs"]:
-                cost.pop("compute")
+                cost.pop("compute", None)
         elif source['type'] == "pgr":
             source.pop("mapping", None)
             bid_tmp = source["storage"]["base"]["baseId"]
@@ -476,7 +476,7 @@ def write_road2_config(config, resource, logger, convert_file_paths = True):
                     source["storage"]["base"].update({"schema":base["schema"]})
             source["storage"]["base"].pop("baseId", None)
             for cost in source["costs"]:
-                cost.pop("compute")
+                cost.pop("compute", None)
         else:
             continue
 


### PR DESCRIPTION
When creating road2config, some attributes are removed with `pop`. Theses attributes are not needed for road2 and should not raise an exception if not defined in the input .json