### PR TITLE
[ci] delete doc deployment on tags

### DIFF
--- a/.github/workflows/docker_publish.yml
+++ b/.github/workflows/docker_publish.yml
@@ -6,8 +6,6 @@ name: Docker GitHub Container Registry
 # documentation.
 
 on:
-  #schedule:
-  #  - cron: '40 18 * * *'
   push:
     branches: [ "master" ]
     # Publish semver tags as releases.

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -5,8 +5,6 @@ on:
   # Runs on pushes targeting the default branch
   push:
     branches: ["master"]
-    # Publish semver tags as releases.
-    tags: [ '*.*.*' ]
   pull_request:
     branches: [ "master", "develop" ]
 

--- a/changelog.md
+++ b/changelog.md
@@ -5,6 +5,7 @@
 CHANGED:
 - reference de la doc à la branche master
 - modification de la ci github pour prendre en compte la branche master
+- suppression du déploiement de github pages lors d'un tag
 
 ## 2.2.0
 


### PR DESCRIPTION
We want to publish the doc related to the last master commit and not to a tag.