### PR TITLE
Feat/apply vacuum to schema only

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,9 @@
 
 ## NEXT-VERSION
 
+ADDED:
+- VACUUM ANALYSE is done only on created tables
+
 FIX:
 - Durée de parcours incohérente sur OSRM entre car-fastest et car-shortest
 

--- a/r2gg/_pivot_to_pgr.py
+++ b/r2gg/_pivot_to_pgr.py
@@ -356,12 +356,31 @@ def pivot_to_pgr(source, cost_calculation_file_path, connection_work, connection
 
     old_isolation_level = connection_out.isolation_level
     connection_out.set_isolation_level(0)
-    vacuum_query = "VACUUM ANALYZE;"
+
+    # VACCUM ANALYZE for ways
+    vacuum_query = f"VACUUM ANALYZE {ways_table_name};"
     logger.info("SQL: {}".format(vacuum_query))
     st_execute = time.time()
     cursor_out.execute(vacuum_query)
     et_execute = time.time()
     logger.info("Execution ended. Elapsed time : %s seconds." %(et_execute - st_execute))
+
+    # VACCUM ANALYZE for ways_vertices_pgr
+    vacuum_query = f"VACUUM ANALYZE {ways_table_name}_vertices_pgr;"
+    logger.info("SQL: {}".format(vacuum_query))
+    st_execute = time.time()
+    cursor_out.execute(vacuum_query)
+    et_execute = time.time()
+    logger.info("Execution ended. Elapsed time : %s seconds." %(et_execute - st_execute))
+
+    # VACCUM ANALYZE for turn_restrictions
+    vacuum_query = f"VACUUM ANALYZE {schema}.turn_restrictions;"
+    logger.info("SQL: {}".format(vacuum_query))
+    st_execute = time.time()
+    cursor_out.execute(vacuum_query)
+    et_execute = time.time()
+    logger.info("Execution ended. Elapsed time : %s seconds." %(et_execute - st_execute))
+
     connection_out.set_isolation_level(old_isolation_level)
     connection_out.commit()
 

--- a/sql/bdtopo_v3.3.sql
+++ b/sql/bdtopo_v3.3.sql
@@ -347,4 +347,6 @@ DROP FOREIGN TABLE IF EXISTS {output_schema}.troncon_de_route CASCADE;
 DROP FOREIGN TABLE IF EXISTS {output_schema}.non_communication CASCADE;
 
 END TRANSACTION;
-VACUUM ANALYZE;
+VACUUM ANALYZE {output_schema}.non_comm;
+VACUUM ANALYZE {output_schema}.edges;
+VACUUM ANALYZE {output_schema}.nodes;

--- a/sql/bduni_convert.sql
+++ b/sql/bduni_convert.sql
@@ -343,4 +343,6 @@ DROP FOREIGN TABLE IF EXISTS {output_schema}.troncon_de_route CASCADE;
 DROP FOREIGN TABLE IF EXISTS {output_schema}.non_communication CASCADE;
 
 END TRANSACTION;
-VACUUM ANALYZE;
+VACUUM ANALYZE {output_schema}.non_comm;
+VACUUM ANALYZE {output_schema}.edges;
+VACUUM ANALYZE {output_schema}.nodes;


### PR DESCRIPTION
If the database used for pivot or pgr is also used for other services, a `VACUUM ANALYSE` command can be quite long.

This PR limit `VACUUM ANALYSE` command only to the created tables.

- `non_comm` / `edges` / `nodes` for pivot table
- `ways` / `ways_vertices_pgr` / `turn_restrictions` for pgr