### PR TITLE
2.2.4: change(pivot2pgr): do not use clean_graph() procedure

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,11 @@
 
 ## x.y.z
 
+## 2.2.4
+
+CHANGED:
+- Pivot to pgr: Not using clean_grpah method anymore, but a SQL query
+
 ## 2.2.3
 
 CHANGED:

--- a/r2gg/__about__.py
+++ b/r2gg/__about__.py
@@ -34,7 +34,7 @@ __uri_repository__ = "https://github.com/IGNF/route-graph-generator/"
 __uri_tracker__ = f"{__uri_repository__}issues/"
 __uri__ = __uri_repository__
 
-__version__ = "2.2.3"
+__version__ = "2.2.4"
 __version_info__ = tuple(
     [
         int(num) if num.isdigit() else num


### PR DESCRIPTION
Using a SQL query instead of the clean_graph() procedure in the pivot2pgr script seems to be more efficient.
The SQL query does the same thing as the procedure, and is slightly different due to the difference between syntaxes. 