### PR TITLE
Feat/check subprocess return code

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,7 @@
 
 CHANGED:
 - Valhalla build config: increase default isochrone limits
+- subprocess : check return code and raise Runtime exception if not 0
 
 ## 2.2.4
 

--- a/r2gg/_subprocess_execution.py
+++ b/r2gg/_subprocess_execution.py
@@ -14,7 +14,8 @@ def subprocess_execution(args, logger, outfile = None):
     """
     try:
         str_args = [str(arg) for arg in args]
-        logger.info('Subprocess: \"' + " ".join(str_args) + '\"')
+        subprocess_arg = " ".join(str_args)
+        logger.info('Subprocess: \"' + subprocess_arg + '\"')
         if outfile is not None:
             with open(outfile, "w") as out:
                 process = subprocess.Popen(
@@ -31,6 +32,12 @@ def subprocess_execution(args, logger, outfile = None):
             )
             process_output, _ =  process.communicate()
             logger.info(process_output.decode("utf-8"))
+
+        returncode = process.returncode
+        if process.returncode != 0:
+            error_msg = f"Invalid returncode {returncode} for subprocess '{subprocess_arg}'"
+            logger.error(error_msg)
+            raise RuntimeError(error_msg)
 
 
     except (OSError, subprocess.CalledProcessError) as exception:


### PR DESCRIPTION
In this PR we check return code for all subprocess in route-graph-generator.

 If the return code is different than 0 it mean that an error occured in the process. 

In this case we should not continue and we raise a RuntimeError.