### PR TITLE
fix(subprocess): wait for process stop in case of None returncode

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,11 @@
 
 ## x.y.z
 
+## 2.2.6
+
+FIXED:
+- subprocess : None value can be returned as returncode. Need to wait for process stop in this case
+
 ## 2.2.5
 
 CHANGED:

--- a/r2gg/_subprocess_execution.py
+++ b/r2gg/_subprocess_execution.py
@@ -33,9 +33,12 @@ def subprocess_execution(args, logger, outfile = None):
             process_output, _ =  process.communicate()
             logger.info(process_output.decode("utf-8"))
 
-        returncode = process.returncode
+        # Wait for process stop
+        while process.returncode is None:
+            process.wait()
+
         if process.returncode != 0:
-            error_msg = f"Invalid returncode {returncode} for subprocess '{subprocess_arg}'"
+            error_msg = f"Invalid returncode {process.returncode} for subprocess '{subprocess_arg}'"
             logger.error(error_msg)
             raise RuntimeError(error_msg)
 


### PR DESCRIPTION
subprocesse [Popen.communicate function](https://docs.python.org/3/library/subprocess.html#subprocess.Popen.communicate) should wait for process stop.

It seems that in some cases the process is not finished because a `None` value was returned by `valhalla_build_config` command.

We need to wait for process stop before checking returncode.